### PR TITLE
add some anti spam stuff + add cmds for temp private channel handling

### DIFF
--- a/discordbot.py
+++ b/discordbot.py
@@ -253,12 +253,10 @@ wikiroles = {
 }
 blacklisted=[
 	"https://drive.google.com/file/d/1dSO7W1WJiRcvWfOPoq6DjLDIvkFzyYn1",
-	"It seems that despite how much evidence I've provided"
 	#more blacklisted strings here (can also be added via "!fobot blacklist <string>" - can be removed via "!fobot remove_blacklist <string>")
 ]
 blacklisteduser=[
-        "Moataz"
-	#more blacklisted usernames here (can also be added via "!fobot blacklist_user <username>" - can be removed via "!fobot remove_blacklist_user <username>")
+	#blacklisted usernames here (can be added via "!fobot blacklist_user <username>" - can be removed via "!fobot remove_blacklist_user <username>")
 ]
 reactionspammers=[]
 countchannelmessagemax = 100
@@ -457,7 +455,7 @@ async def on_message(message):
 	global sbotroles
 	global wikiroles
 	global wikis
-	if message.author.name in blacklisteduser or check_blacklisted(message.content) or (len(message.role_mentions) + len(message.mentions)) > 3:
+	if message.author.name in blacklisteduser or check_blacklisted(message.content) or (len(message.role_mentions) + len(message.mentions)) >= 5:
 		if (datetime.datetime.utcnow() - message.author.joined_at).days <= 7:
 			await message.guild.ban(message.author, reason="automated ban, usage of blacklisted username/phrase or mass ping")
 	if message.channel.name in wikis:

--- a/discordbot.py
+++ b/discordbot.py
@@ -629,7 +629,7 @@ async def create(ctx, member: discord.Member):
     else:
         guild = ctx.message.guild
         admin_role1 = discord.utils.get(guild.roles, name="Admins")
-	admin_role2 = discord.utils.get(guild.roles, name="Liquipedia Staff")
+        admin_role2 = discord.utils.get(guild.roles, name="Liquipedia Staff")
         overwrites = {
             guild.default_role: discord.PermissionOverwrite(read_messages=False),
             guild.me: discord.PermissionOverwrite(read_messages=True),
@@ -638,7 +638,7 @@ async def create(ctx, member: discord.Member):
             member: discord.PermissionOverwrite(read_messages=True)
         }
         await guild.create_text_channel('temp_' + member.name, overwrites=overwrites, category=bot.get_channel(int(discordbottoken.privcat)))
-	await ctx.send('This channel was created to discuss the private request of ' + member.mention)
+        await ctx.send('This channel was created to discuss the private request of ' + member.mention)
         await ctx.message.delete()
 
 @bot.command(

--- a/discordbot.py
+++ b/discordbot.py
@@ -630,7 +630,6 @@ async def create(ctx, member: discord.Member):
         guild = ctx.message.guild
         admin_role1 = discord.utils.get(guild.roles, name="Admins")
 	admin_role2 = discord.utils.get(guild.roles, name="Liquipedia Staff")
-        private_role = discord.utils.get(guild.roles, name="Private Chat")
         overwrites = {
             guild.default_role: discord.PermissionOverwrite(read_messages=False),
             guild.me: discord.PermissionOverwrite(read_messages=True),

--- a/discordbot.py
+++ b/discordbot.py
@@ -649,158 +649,156 @@ async def on_message(message):
 						await message.channel.send(embed=discord.Embed(colour=discord.Colour(0x00ffff), description=result))
 
 @bot.command(
-        help='Deletes the specified amount of messages of the specified channel. If no channel is specified it will purge the channel the command was issued in.\nUsage: "!fobot purge <channelname> <amount of messages to be deleted>"',
-        brief='Deletes all messages of the specified channel.'
+	help='Deletes the specified amount of messages of the specified channel. If no channel is specified it will purge the channel the command was issued in.\nUsage: "!fobot purge <channelname> <amount of messages to be deleted>"',
+	brief='Deletes all messages of the specified channel.'
 )
 async def purge(ctx, channel_name=None, number=100):
-    user = ctx.message.author
-    if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
-            await ctx.send('You do not have permission to use this command.')
-    else:
-        if channel_name == None: channel = ctx.channel
-        else: channel = discord.utils.get(ctx.guild.channels, name=channel_name)
-        if channel == None: await ctx.send('Invalid channel.')
-        await channel.purge(limit=number)
+	user = ctx.message.author
+	if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
+		await ctx.send('You do not have permission to use this command.')
+	else:
+		if channel_name == None: channel = ctx.channel
+		else: channel = discord.utils.get(ctx.guild.channels, name=channel_name)
+		if channel == None: await ctx.send('Invalid channel.')
+		await channel.purge(limit=number)
 
 @bot.command(
-        help='Creates a temp. private channel and invites the specified user to it.\nUsage: "!fobot create <user>"',
-        brief='Creates a temp. private channel and invites the specified user to it.'
+	help='Creates a temp. private channel and invites the specified user to it.\nUsage: "!fobot create <user>"',
+	brief='Creates a temp. private channel and invites the specified user to it.'
 )
 async def create(ctx, member: discord.Member):
-    user = ctx.message.author
-    if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
-            await ctx.send('You do not have permission to use this command.')
-    else:
-        guild = ctx.message.guild
-        admin_role1 = discord.utils.get(guild.roles, name="Admins")
-        admin_role2 = discord.utils.get(guild.roles, name="Liquipedia Staff")
-        overwrites = {
-            guild.default_role: discord.PermissionOverwrite(read_messages=False),
-            guild.me: discord.PermissionOverwrite(read_messages=True),
-            admin_role1: discord.PermissionOverwrite(read_messages=True),
-            admin_role2: discord.PermissionOverwrite(read_messages=True),
-            member: discord.PermissionOverwrite(read_messages=True)
-        }
-        await guild.create_text_channel('temp_' + member.name, overwrites=overwrites, category=bot.get_channel(int(discordbottoken.privcat)))
-        await ctx.send('This channel was created to discuss the private request of ' + member.mention)
-        await ctx.message.delete()
+	user = ctx.message.author
+	if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
+		await ctx.send('You do not have permission to use this command.')
+	else:
+		guild = ctx.message.guild
+		admin_role1 = discord.utils.get(guild.roles, name="Admins")
+		admin_role2 = discord.utils.get(guild.roles, name="Liquipedia Staff")
+		overwrites = {
+			guild.default_role: discord.PermissionOverwrite(read_messages=False),
+			guild.me: discord.PermissionOverwrite(read_messages=True),
+ 			admin_role1: discord.PermissionOverwrite(read_messages=True),
+			admin_role2: discord.PermissionOverwrite(read_messages=True),
+			member: discord.PermissionOverwrite(read_messages=True)
+		}
+		await guild.create_text_channel('temp_' + member.name, overwrites=overwrites, category=bot.get_channel(int(discordbottoken.privcat)))
+		await ctx.send('This channel was created to discuss the private request of ' + member.mention)
+		await ctx.message.delete()
 
 @bot.command(
-        help='Copies the specified channel (up to 10,000 msgs) to "Private_chat_log". If no channel is specified it will copy the channel the command was issued in. Only works in channels that start with "temp_".\nUsage: "!fobot copy <channelname>"',
-        brief='Copies the specified channel to "Private_chat_log".'
+	help='Copies the specified channel (up to 10,000 msgs) to "Private_chat_log". If no channel is specified it will copy the channel the command was issued in. Only works in channels that start with "temp_".\nUsage: "!fobot copy <channelname>"',
+	brief='Copies the specified channel to "Private_chat_log".'
 )
 async def copy(ctx, channel_name=None):
-    user = ctx.message.author
-    if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
-            await ctx.send('You do not have permission to use this command.')
-    else:
-        if channel_name == None: channel = ctx.channel
-        else: channel = discord.utils.get(ctx.guild.channels, name=channel_name)
-        if channel == None or not channel.name.startswith('temp_'): await ctx.send('Invalid channel.')
-        else:
-            epmty_array = []
-            logtarget = bot.get_channel(discordbottoken.logtarget)
-            async for message in channel.history(limit=10000, oldest_first='true'):
-                time = message.created_at
-                embed = discord.Embed(
-                    title=message.author.display_name + ' on ' + str(time)[:-7] + ' UTC:',
-                    color=discord.Color.blue(),
-                    description=message.content
-                    )
-                await logtarget.send(embed=embed)
-                if message.attachments != epmty_array:
-                    files = message.attachments
-                    for file in files:
-                        await logtarget.send(file.url)
+	user = ctx.message.author
+	if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
+		await ctx.send('You do not have permission to use this command.')
+	else:
+		if channel_name == None: channel = ctx.channel
+		else: channel = discord.utils.get(ctx.guild.channels, name=channel_name)
+		if channel == None or not channel.name.startswith('temp_'): await ctx.send('Invalid channel.')
+		else:
+			epmty_array = []
+			logtarget = bot.get_channel(discordbottoken.logtarget)
+			async for message in channel.history(limit=10000, oldest_first='true'):
+				time = message.created_at
+				embed = discord.Embed(
+					title=message.author.display_name + ' on ' + str(time)[:-7] + ' UTC:',
+					color=discord.Color.blue(),
+					description=message.content
+				)
+				await logtarget.send(embed=embed)
+				if message.attachments != epmty_array:
+				files = message.attachments
+				for file in files:
+					await logtarget.send(file.url)
 
 @bot.command(
-        help='Copies the specified channel to "Private_chat_log" and deletes it thereafter. If no channel is specified it defaults to the channel the command was issued in. Only works in channels that start with "temp_".\nUsage: "!fobot kill_channel <channelname>"',
-        brief='Copies the specified channel to "Private_chat_log" and deletes it thereafter.'
+	help='Copies the specified channel to "Private_chat_log" and deletes it thereafter. If no channel is specified it defaults to the channel the command was issued in. Only works in channels that start with "temp_".\nUsage: "!fobot kill_channel <channelname>"',
+	brief='Copies the specified channel to "Private_chat_log" and deletes it thereafter.'
 )
 async def kill_channel(ctx, channel_name=None):
-    user = ctx.message.author
-    if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
-            await ctx.send('You do not have permission to use this command.')
-    else:
-        if channel_name == None: channel = ctx.channel
-        else: channel = discord.utils.get(ctx.guild.channels, name=channel_name)
-        if channel == None or not channel.name.startswith('temp_'): await ctx.send('Invalid channel.')
-        else:
-            epmty_array = []
-            logtarget = bot.get_channel(discordbottoken.logtarget)
-            async for message in channel.history(limit=10000, oldest_first='true'):
-                time = message.created_at
-                embed = discord.Embed(
-                    title=message.author.name + ' on ' + str(time)[:-7] + ' UTC:',
-                    color=discord.Color.blue(),
-                    description=message.content
-                    )
-                await logtarget.send(embed=embed)
-                if message.attachments != epmty_array:
-                    files = message.attachments
-                    for file in files:
-                        await logtarget.send(file.url)
-                else:None
-                        
-            await channel.delete()
+	user = ctx.message.author
+	if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
+		await ctx.send('You do not have permission to use this command.')
+	else:
+		if channel_name == None: channel = ctx.channel
+		else: channel = discord.utils.get(ctx.guild.channels, name=channel_name)
+		if channel == None or not channel.name.startswith('temp_'): await ctx.send('Invalid channel.')
+		else:
+			epmty_array = []
+			logtarget = bot.get_channel(discordbottoken.logtarget)
+			async for message in channel.history(limit=10000, oldest_first='true'):
+				time = message.created_at
+				embed = discord.Embed(
+					title=message.author.name + ' on ' + str(time)[:-7] + ' UTC:',
+					color=discord.Color.blue(),
+					description=message.content
+				)
+				await logtarget.send(embed=embed)
+				if message.attachments != epmty_array:
+					files = message.attachments
+					for file in files:
+						await logtarget.send(file.url)
+				else:None
+			await channel.delete()
 
 @bot.command(
-        help='Adds a string to the blacklisted strings.\nUsage: "!fobot blacklist <string>"',
-        brief='Adds a string to the blacklisted strings.'
+	help='Adds a string to the blacklisted strings.\nUsage: "!fobot blacklist <string>"',
+	brief='Adds a string to the blacklisted strings.'
 )
 async def blacklist(ctx, *, strg):
-    user = ctx.message.author
-    if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
-            await ctx.send('You do not have permission to use this command.')
-    else:
-        if strg != None:
-            blacklisted.append(strg)
-            await ctx.send(strg + ' now blacklisted.')
+	user = ctx.message.author
+	if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
+		await ctx.send('You do not have permission to use this command.')
+	else:
+		if strg != None:
+			blacklisted.append(strg)
+			await ctx.send(strg + ' now blacklisted.')
 
 @bot.command(
-        help='Removes a string to the blacklisted strings.\nUsage: "!fobot remove_blacklist <string>"',
-        brief='Removes a string to the blacklisted strings.'
+	help='Removes a string to the blacklisted strings.\nUsage: "!fobot remove_blacklist <string>"',
+	brief='Removes a string to the blacklisted strings.'
 )
 async def remove_blacklist(ctx, *, strg=None):
-    user = ctx.message.author
-    if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
-            await ctx.send('You do not have permission to use this command.')
-    else:
-        if strg != None and strg in blacklisted:
-            blacklisted.remove(strg)
-            await ctx.send('"' + strg + '" now removed from blacklist.')
+	user = ctx.message.author
+	if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
+		await ctx.send('You do not have permission to use this command.')
+	else:
+		if strg != None and strg in blacklisted:
+		blacklisted.remove(strg)
+		await ctx.send('"' + strg + '" now removed from blacklist.')
 
 @bot.command(
-        help='Adds a username to the blacklisted usernames.\nUsage: "!fobot blacklist_user <username>"',
-        brief='Adds a string to the blacklisted strings.'
+	help='Adds a username to the blacklisted usernames.\nUsage: "!fobot blacklist_user <username>"',
+	brief='Adds a string to the blacklisted strings.'
 )
 async def blacklist_user(ctx, username=None):
-    user = ctx.message.author
-    if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
-            await ctx.send('You do not have permission to use this command.')
-    else:
-        if username != None:
-            blacklisteduser.append(username)
-            await ctx.send(username + ' now blacklisted.')
+	user = ctx.message.author
+	if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
+		await ctx.send('You do not have permission to use this command.')
+	else:
+		if username != None:
+		blacklisteduser.append(username)
+		await ctx.send(username + ' now blacklisted.')
 
 @bot.command(
-        help='Removes a username to the blacklisted usernames.\nUsage: "!fobot remove_blacklist_user <username>"',
-        brief='Removes a string to the blacklisted strings.'
+	help='Removes a username to the blacklisted usernames.\nUsage: "!fobot remove_blacklist_user <username>"',
+	brief='Removes a string to the blacklisted strings.'
 )
 async def remove_blacklist_user(ctx, username=None):
-    user = ctx.message.author
-    if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
-            await ctx.send('You do not have permission to use this command.')
-    else:
-        if username != None and strg in blacklisted:
-            blacklisteduser.remove(username)
-            await ctx.send(username + ' now removed from blacklist.')
+	user = ctx.message.author
+	if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
+		await ctx.send('You do not have permission to use this command.')
+	elif username != None and strg in blacklisted:
+		blacklisteduser.remove(username)
+		await ctx.send(username + ' now removed from blacklist.')
 
 #@create.error
 async def create_error(ctx, error):
-    if isinstance(error, commands.BadArgument):
-        await ctx.send('Invalid argument.')
-    if isinstance(error, commands.MissingRequiredArgument):
-        await ctx.send('Please specify an argument.')
+	if isinstance(error, commands.BadArgument):
+		await ctx.send('Invalid argument.')
+	if isinstance(error, commands.MissingRequiredArgument):
+		await ctx.send('Please specify an argument.')
 
 bot.run(discordbottoken.token)

--- a/discordbot.py
+++ b/discordbot.py
@@ -251,13 +251,6 @@ wikiroles = {
 	'editor': 'Editor',
 	'reviewer': 'Reviewer'
 }
-blacklisted=[
-	"https://drive.google.com/file/d/1dSO7W1WJiRcvWfOPoq6DjLDIvkFzyYn1",
-	#more blacklisted strings here (can also be added via "!fobot blacklist <string>" - can be removed via "!fobot remove_blacklist <string>")
-]
-blacklisteduser=[
-	#blacklisted usernames here (can be added via "!fobot blacklist_user <username>" - can be removed via "!fobot remove_blacklist_user <username>")
-]
 reactionspammers=[]
 countchannelmessagemax = 100
 countchannelmessage = {}
@@ -455,9 +448,9 @@ async def on_message(message):
 	global sbotroles
 	global wikiroles
 	global wikis
-	if message.author.name in blacklisteduser or check_blacklisted(message.content) or (len(message.role_mentions) + len(message.mentions)) >= 5:
+	if (len(message.role_mentions) + len(message.mentions)) >= 5:
 		if (datetime.datetime.utcnow() - message.author.joined_at).days <= 7:
-			await message.guild.ban(message.author, reason="automated ban, usage of blacklisted username/phrase or mass ping")
+			await message.guild.ban(message.author, reason="automated ban, mass ping")
 	if message.channel.name in wikis:
 		countchannelmessage[message.channel.name] += 1
 	if message.content == '!fobot' or message.content.startswith('!fobot'):
@@ -740,57 +733,6 @@ async def kill_channel(ctx, channel_name=None):
 						await logtarget.send(file.url)
 				else:None
 			await channel.delete()
-
-@bot.command(
-	help='Adds a string to the blacklisted strings.\nUsage: "!fobot blacklist <string>"',
-	brief='Adds a string to the blacklisted strings.'
-)
-async def blacklist(ctx, *, strg):
-	user = ctx.message.author
-	if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
-		await ctx.send('You do not have permission to use this command.')
-	else:
-		if strg != None:
-			blacklisted.append(strg)
-			await ctx.send(strg + ' now blacklisted.')
-
-@bot.command(
-	help='Removes a string to the blacklisted strings.\nUsage: "!fobot remove_blacklist <string>"',
-	brief='Removes a string to the blacklisted strings.'
-)
-async def remove_blacklist(ctx, *, strg=None):
-	user = ctx.message.author
-	if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
-		await ctx.send('You do not have permission to use this command.')
-	else:
-		if strg != None and strg in blacklisted:
-		blacklisted.remove(strg)
-		await ctx.send('"' + strg + '" now removed from blacklist.')
-
-@bot.command(
-	help='Adds a username to the blacklisted usernames.\nUsage: "!fobot blacklist_user <username>"',
-	brief='Adds a string to the blacklisted strings.'
-)
-async def blacklist_user(ctx, username=None):
-	user = ctx.message.author
-	if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
-		await ctx.send('You do not have permission to use this command.')
-	else:
-		if username != None:
-		blacklisteduser.append(username)
-		await ctx.send(username + ' now blacklisted.')
-
-@bot.command(
-	help='Removes a username to the blacklisted usernames.\nUsage: "!fobot remove_blacklist_user <username>"',
-	brief='Removes a string to the blacklisted strings.'
-)
-async def remove_blacklist_user(ctx, username=None):
-	user = ctx.message.author
-	if not discord.utils.get(user.roles, name="Admins") and not discord.utils.get(user.roles, name="Liquipedia Staff"):
-		await ctx.send('You do not have permission to use this command.')
-	elif username != None and strg in blacklisted:
-		blacklisteduser.remove(username)
-		await ctx.send(username + ' now removed from blacklist.')
 
 #@create.error
 async def create_error(ctx, error):

--- a/discordbot.py
+++ b/discordbot.py
@@ -605,7 +605,7 @@ async def on_message(message):
 						await message.channel.send(embed=discord.Embed(colour=discord.Colour(0x00ffff), description=result))
 
 @bot.command(
-	help='Deletes messages of the specified channel. If no channel is specified it will purge the channel the command was issued in.\nUsage: "!fobot purge <channelname> <amount of messages to be deleted>"',
+	help='Deletes the specified amount of messages of the specified channel. If no channel is specified it will purge the channel the command was issued in.\nUsage: "!fobot purge <channelname> <amount of messages to be deleted>"',
         brief='Deletes all messages of the specified channel.'
 )
 async def purge(ctx, channel_name=None, number=100):
@@ -628,15 +628,18 @@ async def create(ctx, member: discord.Member):
             await ctx.send('You do not have permission to use this command.')
     else:
         guild = ctx.message.guild
-        admin_role = discord.utils.get(guild.roles, name="Admins")
+        admin_role1 = discord.utils.get(guild.roles, name="Admins")
+	admin_role2 = discord.utils.get(guild.roles, name="Liquipedia Staff")
         private_role = discord.utils.get(guild.roles, name="Private Chat")
         overwrites = {
             guild.default_role: discord.PermissionOverwrite(read_messages=False),
             guild.me: discord.PermissionOverwrite(read_messages=True),
-            admin_role: discord.PermissionOverwrite(read_messages=True),
+            admin_role1: discord.PermissionOverwrite(read_messages=True),
+            admin_role2: discord.PermissionOverwrite(read_messages=True),
             member: discord.PermissionOverwrite(read_messages=True)
         }
         await guild.create_text_channel('temp_' + member.name, overwrites=overwrites, category=bot.get_channel(int(discordbottoken.privcat)))
+	await ctx.send('This channel was created to discuss the private request of ' + member.mention)
         await ctx.message.delete()
 
 @bot.command(

--- a/discordbot.py
+++ b/discordbot.py
@@ -649,7 +649,7 @@ async def on_message(message):
 						await message.channel.send(embed=discord.Embed(colour=discord.Colour(0x00ffff), description=result))
 
 @bot.command(
-	help='Deletes the specified amount of messages of the specified channel. If no channel is specified it will purge the channel the command was issued in.\nUsage: "!fobot purge <channelname> <amount of messages to be deleted>"',
+        help='Deletes the specified amount of messages of the specified channel. If no channel is specified it will purge the channel the command was issued in.\nUsage: "!fobot purge <channelname> <amount of messages to be deleted>"',
         brief='Deletes all messages of the specified channel.'
 )
 async def purge(ctx, channel_name=None, number=100):
@@ -663,7 +663,7 @@ async def purge(ctx, channel_name=None, number=100):
         await channel.purge(limit=number)
 
 @bot.command(
-	help='Creates a temp. private channel and invites the specified user to it.\nUsage: "!fobot create <user>"',
+        help='Creates a temp. private channel and invites the specified user to it.\nUsage: "!fobot create <user>"',
         brief='Creates a temp. private channel and invites the specified user to it.'
 )
 async def create(ctx, member: discord.Member):
@@ -686,7 +686,7 @@ async def create(ctx, member: discord.Member):
         await ctx.message.delete()
 
 @bot.command(
-	help='Copies the specified channel (up to 10,000 msgs) to "Private_chat_log". If no channel is specified it will copy the channel the command was issued in. Only works in channels that start with "temp_".\nUsage: "!fobot copy <channelname>"',
+        help='Copies the specified channel (up to 10,000 msgs) to "Private_chat_log". If no channel is specified it will copy the channel the command was issued in. Only works in channels that start with "temp_".\nUsage: "!fobot copy <channelname>"',
         brief='Copies the specified channel to "Private_chat_log".'
 )
 async def copy(ctx, channel_name=None):
@@ -714,7 +714,7 @@ async def copy(ctx, channel_name=None):
                         await logtarget.send(file.url)
 
 @bot.command(
-	help='Copies the specified channel to "Private_chat_log" and deletes it thereafter. If no channel is specified it defaults to the channel the command was issued in. Only works in channels that start with "temp_".\nUsage: "!fobot kill_channel <channelname>"',
+        help='Copies the specified channel to "Private_chat_log" and deletes it thereafter. If no channel is specified it defaults to the channel the command was issued in. Only works in channels that start with "temp_".\nUsage: "!fobot kill_channel <channelname>"',
         brief='Copies the specified channel to "Private_chat_log" and deletes it thereafter.'
 )
 async def kill_channel(ctx, channel_name=None):
@@ -745,7 +745,7 @@ async def kill_channel(ctx, channel_name=None):
             await channel.delete()
 
 @bot.command(
-	help='Adds a string to the blacklisted strings.\nUsage: "!fobot blacklist <string>"',
+        help='Adds a string to the blacklisted strings.\nUsage: "!fobot blacklist <string>"',
         brief='Adds a string to the blacklisted strings.'
 )
 async def blacklist(ctx, *, strg):
@@ -758,7 +758,7 @@ async def blacklist(ctx, *, strg):
             await ctx.send(strg + ' now blacklisted.')
 
 @bot.command(
-	help='Removes a string to the blacklisted strings.\nUsage: "!fobot remove_blacklist <string>"',
+        help='Removes a string to the blacklisted strings.\nUsage: "!fobot remove_blacklist <string>"',
         brief='Removes a string to the blacklisted strings.'
 )
 async def remove_blacklist(ctx, *, strg=None):
@@ -771,7 +771,7 @@ async def remove_blacklist(ctx, *, strg=None):
             await ctx.send('"' + strg + '" now removed from blacklist.')
 
 @bot.command(
-	help='Adds a username to the blacklisted usernames.\nUsage: "!fobot blacklist_user <username>"',
+        help='Adds a username to the blacklisted usernames.\nUsage: "!fobot blacklist_user <username>"',
         brief='Adds a string to the blacklisted strings.'
 )
 async def blacklist_user(ctx, username=None):
@@ -784,7 +784,7 @@ async def blacklist_user(ctx, username=None):
             await ctx.send(username + ' now blacklisted.')
 
 @bot.command(
-	help='Removes a username to the blacklisted usernames.\nUsage: "!fobot remove_blacklist_user <username>"',
+        help='Removes a username to the blacklisted usernames.\nUsage: "!fobot remove_blacklist_user <username>"',
         brief='Removes a string to the blacklisted strings.'
 )
 async def remove_blacklist_user(ctx, username=None):

--- a/discordbot.py
+++ b/discordbot.py
@@ -15,7 +15,10 @@ import urllib
 from discord.ext import commands
 import asyncio
 
-bot = commands.Bot(command_prefix = '!fobot ')
+intents = discord.Intents.default()
+intents.members = True
+
+bot = commands.Bot(command_prefix = '!fobot ', intents=intents)
 client = bot
 
 muted = False
@@ -424,6 +427,13 @@ async def on_ready():
 	while True:
 		await asyncio.sleep(60)#sets the time after which the reaction spamm list is cleared
 		reactionspammers.clear()
+
+@client.event
+async def on_member_join(member):
+	#check if user account was created within last day
+	if (datetime.datetime.utcnow() - member.created_at).days <= 1:
+		role = discord.utils.get(member.guild.roles, name="Muted")
+		await member.add_roles(role)
                 
 @client.event
 async def on_reaction_add(reaction, user):

--- a/discordbottoken.py
+++ b/discordbottoken.py
@@ -1,2 +1,4 @@
 token = ''
 apikey = ''
+logtarget = #here the channel id of the channel we want the private channel logs to be stored in
+privcat = 360564294401916929 #this is the id of the "Private Channels" Category


### PR DESCRIPTION
uses @bot.command instead of message.content.startswith for the new commands, so some small changes to the existing code are needed apart from adding the new cmds

new commands (ONLY USABLE WITH "Liquipedia Staff" or "Admins" role and if fobot is not muted) are:

- _!fobot purge <channelname> <amount of messages to be deleted>_ --> Deletes messages of the specified channel. If no channel is specified it will purge the channel the command was issued in. Amount defaults to 100.
- _!fobot copy <channelname>_ --> Copies the specified channel (up to 10,000 msgs) to "Private_chat_log". If no channel is specified it will copy the channel the command was issued in. Only works in channels that start with "temp_".
- _!fobot kill_channel <channelname>_ --> Copies the specified channel to "Private_chat_log" and deletes it thereafter. If no channel is specified it defaults to the channel the command was issued in. Only works in channels that start with "temp_".
- _!fobot create <user>_ --> Creates a temp. private channel and invites the specified user to it.

new cmds have a help info that can be shown via !fobot help <cmd-name>

- [ ] also needs 2 entries ("logtarget", the id of the channel we want to store stuff in and "privcat", the id of the Private Channels Category (360564294401916929)) to discordbottoken.py for the cmds copy, create and kill_channel to work properly

Commit against Moataz:
Adds a anti-reaction spam functionality. (Will ban users whose account did join within the last 7 days and who used >5 reactions within 60 seconds.)
Adds on_member_join event that gives new members whose account was created within the last day the "Muted" role
Tested on private test server.