### PR TITLE
Add anti mass ping functionality

### DIFF
--- a/ftsbot/cogs/antispam.py
+++ b/ftsbot/cogs/antispam.py
@@ -25,6 +25,17 @@ class antispam(commands.Cog):
 			for role in message.role_mentions:
 				if role.name == 'Liquipedia Admins':
 					await message.channel.send('Hello ' + message.author.mention + ', you seem to be new to our server and you have messaged Liquipedia Administrators. If your issue is not of private nature, please just write it in the channel for the game it is about.')
+		if len(message.mentions) > 10 and (datetime.datetime.utcnow() - message.author.joined_at).days <= 100:
+			has_exception_role = 0
+			for role in message.author.roles:
+				if role.name in {'Discord Admins', 'Liquipedia Employee', 'Administrator', 'Editor', 'Reviewer', 'Silver Plus', 'Industry Person'}:
+					has_exception_role = 1
+					break
+			if has_exception_role == 0:
+				try:
+					await member.ban(reason='Automated ban, spam')
+				except discord.Forbidden:
+					pass
 
 	@commands.Cog.listener()
 	async def on_member_join(self, member):


### PR DESCRIPTION
## Summary
Add functionality to automatically ban members that
- ping > 10 people and
- have joined the server within the last 100 days and
- do not have at least one of the following roles:
- - Discord Admins
- - Liquipedia Employee
- - Administrator
- - Editor
- - Reviewer
- - Silver Plus
- - Industry Person

## Tests for this change
tested on private discord server (with different role names)
