### PR TITLE
Adding Splitgate to commands

### DIFF
--- a/ftsbot/data.py
+++ b/ftsbot/data.py
@@ -117,6 +117,7 @@ botroleswikis = [
 	'Runeterra',
 	'Sim Racing',
 	'Smash',
+	'Splitgate'
 	'Starcraft 2',
 	'Starcraft',
 	'Team Fortress',


### PR DESCRIPTION
Adds Splitgate to the FO-BOT wiki role command list (Role also created on Discord)