### PR TITLE
Fix wrong "var"

### DIFF
--- a/ftsbot/cogs/antispam.py
+++ b/ftsbot/cogs/antispam.py
@@ -85,7 +85,7 @@ class antispam(
 					self.pingspammers[message.author.id] = True
 				else:
 					try:
-						await member.ban(reason='Automated ban, spam')
+						await message.author.ban(reason='Automated ban, spam')
 					except discord.Forbidden:
 						pass
 


### PR DESCRIPTION
member is not defined in the `on_message` anywhere so `member.ban` should error
correct should be `message.author.ban`
(Pylance was bitching about it)