### PR TITLE
Add anti @everyone messures

### DIFF
--- a/ftsbot/cogs/antispam.py
+++ b/ftsbot/cogs/antispam.py
@@ -51,10 +51,10 @@ class antispam(
 					has_exception_role = True
 					break
 			if not has_exception_role:
-				#give muted role
+				# give muted role
 				mutedrole = discord.utils.get(message.guild.roles, name='Muted')
 				await message.author.add_roles(mutedrole)
-				#post message in staff channel
+				# post message in staff channel
 				reporttarget = self.bot.get_channel(config.reporttarget)
 				time = message.created_at
 				await reporttarget.send(
@@ -67,7 +67,7 @@ class antispam(
 						description=message.content
 					)
 				)
-				#post response message so that user knows what is going on
+				# post response message so that user knows what is going on
 				await message.channel.send(
 					embed=discord.Embed(
 						colour=discord.Colour(0xff0000),
@@ -77,7 +77,7 @@ class antispam(
 						)
 					)
 				)
-				#delete flagged message
+				# delete flagged message
 				await message.delete()
 		if 'liquidpedia' in message.content.lower():
 			await message.channel.send(

--- a/ftsbot/cogs/antispam.py
+++ b/ftsbot/cogs/antispam.py
@@ -43,11 +43,11 @@ class antispam(
 		if '@everyone' in message.content:
 			has_exception_role = False
 			for role in message.author.roles:
-				if role.name in {
+				if role.name in [
 					'Discord Admins',
 					'Liquipedia Employee',
-					'Administrator'
-				}:
+					'Administrator',
+				]:
 					has_exception_role = True
 					break
 			if not has_exception_role:
@@ -108,15 +108,15 @@ class antispam(
 		):
 			has_exception_role = False
 			for role in message.author.roles:
-				if role.name in {
+				if role.name in [
 					'Discord Admins',
 					'Liquipedia Employee',
 					'Administrator',
 					'Editor',
 					'Reviewer',
 					'Silver Plus',
-					'Industry Person'
-				}:
+					'Industry Person',
+				]:
 					has_exception_role = True
 					break
 			if not has_exception_role:

--- a/ftsbot/cogs/antispam.py
+++ b/ftsbot/cogs/antispam.py
@@ -61,7 +61,8 @@ class antispam(
 					embed=discord.Embed(
 						title=(
 							'Muted for potential (at)everyone spam - '
-							+ message.author.display_name + ' on ' + str(time)[:-7] + ' UTC:'
+							+ message.author.mention + ' on ' + str(time)[:-7] + ' UTC:'
+``` I think this is better, what do you think @hjpalpha ?
 						),
 						color=discord.Color.blue(),
 						description=message.content

--- a/ftsbot/cogs/antispam.py
+++ b/ftsbot/cogs/antispam.py
@@ -62,7 +62,6 @@ class antispam(
 						title=(
 							'Muted for potential (at)everyone spam - '
 							+ message.author.mention + ' on ' + str(time)[:-7] + ' UTC:'
-``` I think this is better, what do you think @hjpalpha ?
 						),
 						color=discord.Color.blue(),
 						description=message.content


### PR DESCRIPTION
what it does:
- exceptions for `Discord Admins, Liquipedia Employee, Administrator`
- apply muted role to someone that tries to tag `@everyone`
- post a message in staff channel so admins get notice of it
- post a message in the channel that the `@everyone` was used, telling the author why they were muted
- delete the offending message (since it most likely is spam)

tested on a private test discord server with a private bot (copied the one from this repo and kicked all the stuff that needs access to lp api and then added the changes)

![Screenshot 2022-12-06 11 26 02](https://user-images.githubusercontent.com/75081997/205889479-6cff86e2-b836-4d9d-bed3-1a3ceadb39ef.png)
![Screenshot 2022-12-06 11 27 05](https://user-images.githubusercontent.com/75081997/205889482-2b507062-44b3-45f6-806f-e84d9ef14872.png)
