### PR TITLE
Mention channel the (at)everyone message originated from

### DIFF
--- a/ftsbot/cogs/antispam.py
+++ b/ftsbot/cogs/antispam.py
@@ -60,12 +60,15 @@ class antispam(
 					embed=discord.Embed(
 						title=(
 							'Muted for potential (at)everyone spam - '
-							+ message.author.mention + ' (@' + message.author.display_name + ')'
-							+ ' in ' + message.channel.mention + ' (#' + message.channel.name + ')'
+							+ message.author.mention + ' in ' + message.channel.mention
 							+ ' on ' + str(time)[:-7] + ' UTC:'
 						),
 						color=discord.Color.blue(),
-						description=message.content
+						description=(
+							message.content
+							# Workaround for mentions not working in embed title on windows
+							+ '\n\nsource: ' + message.author.mention + ' in ' + message.channel.mention
+						)
 					)
 				)
 				# post response message so that user knows what is going on

--- a/ftsbot/cogs/antispam.py
+++ b/ftsbot/cogs/antispam.py
@@ -60,7 +60,8 @@ class antispam(
 					embed=discord.Embed(
 						title=(
 							'Muted for potential (at)everyone spam - '
-							+ message.author.mention + ' in ' + message.channel.mention
+							+ message.author.mention + ' (@' + message.author.display_name + ')'
+							+ ' in ' + message.channel.mention + ' (#' + message.channel.name + ')'
 							+ ' on ' + str(time)[:-7] + ' UTC:'
 						),
 						color=discord.Color.blue(),

--- a/ftsbot/cogs/antispam.py
+++ b/ftsbot/cogs/antispam.py
@@ -60,7 +60,8 @@ class antispam(
 					embed=discord.Embed(
 						title=(
 							'Muted for potential (at)everyone spam - '
-							+ message.author.mention + ' on ' + str(time)[:-7] + ' UTC:'
+							+ message.author.mention + ' in ' + message.channel.mention
+							+ ' on ' + str(time)[:-7] + ' UTC:'
 						),
 						color=discord.Color.blue(),
 						description=message.content


### PR DESCRIPTION
Mention channel the (at)everyone message originated from
Also add plain displayname and plain channel name in brackets so they are readable on web/windows (see below for the why)

tested on private discord


Discord seems to currently have a bug ON DESKTOP AND WEB (windoofs, browser chrome, edge and firefox tested) where it does not display user mentions nor channel mentions in embed headers correctly

on mobile it works just fine

mobile (checked with both android and ios):
![IMG_4339](https://user-images.githubusercontent.com/75081997/209459756-56d48999-71cf-4aa0-b8ef-58283c37762d.jpg)
desktop:
![Screenshot 2022-12-25 08 10 29](https://user-images.githubusercontent.com/75081997/209459757-846281ca-c92c-4646-8036-9ebe606bfa6d.png)

(filled a report (via support.discord.com) but since it is discord i do not have high hopes ...)

workaround solution until discord fixes their mentions in embed titles:
![Screenshot 2022-12-25 16 01 50](https://user-images.githubusercontent.com/75081997/209473053-8f95dd2b-d5bd-44c3-a363-bb7437e6f809.png)

