### PR TITLE
add ML Predictions role to bot

### DIFF
--- a/ftsbot/data.py
+++ b/ftsbot/data.py
@@ -172,9 +172,9 @@ botroles = [
 	'Announcements',
 	'CS Predictions',
 	'Game Night',
+	'ML Predictions',
 	'Please Ping Me',
 	'Random Stats of the Day',
 	'R6 Predictions',
 	'Templates',
-	'ML Predictions',
 ]

--- a/ftsbot/data.py
+++ b/ftsbot/data.py
@@ -176,4 +176,5 @@ botroles = [
 	'Random Stats of the Day',
 	'R6 Predictions',
 	'Templates',
+	'ML Predictions',
 ]


### PR DESCRIPTION
 The Lickypiddy predictions that CS and R6 wiki usually does, ML is also having one
(Role already created in discord)