### PR TITLE
[WiP] Add anti invite spam measures

### DIFF
--- a/ftsbot/cogs/antispam.py
+++ b/ftsbot/cogs/antispam.py
@@ -96,6 +96,7 @@ class antispam(
 					'Discord Admins',
 					'Liquipedia Employee',
 					'Administrator',
+					'Bot',
 				]:
 					has_exception_role = True
 					break

--- a/ftsbot/cogs/antispam.py
+++ b/ftsbot/cogs/antispam.py
@@ -126,7 +126,7 @@ class antispam(
 					embed=discord.Embed(
 						colour=discord.Colour(0xff0000),
 						description=(
-							message.author.mention + ' you have been muted due to trying to potential discord invite spam. '
+							message.author.mention + ' you have been muted due to potential discord invite spam. '
 							+ 'This is a spam bot prevention. Admins will review it at their earliest convenience.'
 						)
 					)

--- a/ftsbot/cogs/antispam.py
+++ b/ftsbot/cogs/antispam.py
@@ -9,6 +9,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 from ftsbot import config
+from ftsbot import data
 from ftsbot.ui.reportform import reportform
 
 
@@ -77,6 +78,55 @@ class antispam(
 						colour=discord.Colour(0xff0000),
 						description=(
 							message.author.mention + ' you have been muted due to trying to use (at)everyone. '
+							+ 'This is a spam bot prevention. Admins will review it at their earliest convenience.'
+						)
+					)
+				)
+				# delete flagged message
+				await message.delete()
+		elif 'discord.gg/' in message.content.lower():
+			has_bad_word = False
+			for bad_word in data.bad_words:
+				if bad_word in message.content.lower():
+					has_bad_word = True
+					break
+			has_exception_role = False
+			for role in message.author.roles:
+				if role.name in [
+					'Discord Admins',
+					'Liquipedia Employee',
+					'Administrator',
+				]:
+					has_exception_role = True
+					break
+			if has_bad_word and not has_exception_role:
+				# give muted role
+				mutedrole = discord.utils.get(message.guild.roles, name='Muted')
+				await message.author.add_roles(mutedrole)
+				# post message in staff channel
+				reporttarget = self.bot.get_channel(config.reporttarget)
+				time = message.created_at
+				await reporttarget.send(
+					embed=discord.Embed(
+						title=(
+							'Muted for potential discord invite link spam - '
+							+ message.author.mention + ' in ' + message.channel.mention
+							+ ' on ' + str(time)[:-7] + ' UTC:'
+						),
+						color=discord.Color.blue(),
+						description=(
+							message.content
+							# Workaround for mentions not working in embed title on windows
+							+ '\n\nsource: ' + message.author.mention + ' in ' + message.channel.mention
+						)
+					)
+				)
+				# post response message so that user knows what is going on
+				await message.channel.send(
+					embed=discord.Embed(
+						colour=discord.Colour(0xff0000),
+						description=(
+							message.author.mention + ' you have been muted due to trying to potential discord invite spam. '
 							+ 'This is a spam bot prevention. Admins will review it at their earliest convenience.'
 						)
 					)

--- a/ftsbot/cogs/antispam.py
+++ b/ftsbot/cogs/antispam.py
@@ -84,7 +84,7 @@ class antispam(
 				)
 				# delete flagged message
 				await message.delete()
-		elif 'discord.gg/' in message.content.lower():
+		elif 'discord.gg' in message.content.lower():
 			has_bad_word = False
 			for bad_word in data.bad_words:
 				if bad_word in message.content.lower():

--- a/ftsbot/data.py
+++ b/ftsbot/data.py
@@ -178,3 +178,17 @@ botroles = [
 	'R6 Predictions',
 	'Templates',
 ]
+
+bad_words = [
+	'nudde',
+	'nude',
+	'sex',
+	's3x',
+	'seex',
+	'tiktok',
+	'18+',
+	'kiss',
+	'onlyfans',
+	'nft',
+	'crypto',
+]

--- a/ftsbot/data.py
+++ b/ftsbot/data.py
@@ -179,6 +179,7 @@ botroles = [
 	'Templates',
 ]
 
+# Words regularly used in invite spams
 bad_words = [
 	'nudde',
 	'nude',


### PR DESCRIPTION
Add anti invite spam measures.

## what it does
- exceptions for `Discord Admins, Liquipedia Employee, Administrator`
- apply muted role to someone that tries to spam invites (discord invite link plus one of the `bad_words` in the same message)
- post a message in staff channel so admins get notice of it
- post a message in the channel that the possible spam invite was used, telling the author why they were muted
- delete the offending message (since it most likely is spam)

## tests
tested on a private test discord server with a private bot (copied the one from this repo and kicked all the stuff that needs access to lp api and then added the changes)

![Screenshot 2023-01-17 17 53 27](https://user-images.githubusercontent.com/75081997/212962207-66ca35c8-4bcb-44ab-9420-1e0672dfde89.png)
![Screenshot 2023-01-17 17 53 52](https://user-images.githubusercontent.com/75081997/212962212-1f765e61-dc79-42c3-a82d-7fa4d27c64d7.png)
