### PR TITLE
Add anti nitro spam measures

### DIFF
--- a/ftsbot/data.py
+++ b/ftsbot/data.py
@@ -193,3 +193,13 @@ bad_words = [
 	'nft',
 	'crypto',
 ]
+
+nitro_spam_triggers = [
+	'discord',
+	'dissord',
+	'discrod',
+	'dissrod',
+	'free',
+	'gift',
+	'giveaway',
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 discord.py>=2.0.0
 requests>=2.26.0
+unidecode>=1.3.6


### PR DESCRIPTION
--> _**Needs unidecode `pip install Unidecode`**_ <--

Add anti nitro spam measures.

## what it does
- exceptions for `Discord Admins, Liquipedia Employee, Administrator, Bot`
- cleanes the input message via `unidecode` to circumvent non standard letters
- apply muted role to someone that tries to spam fake nitro gift links (word `nitro` plus at least 2 additional trigger words)
- post a message in staff channel so admins get notice of it
- post a message in the channel that the possible spam invite was used, telling the author why they were muted
- delete the offending message (since it most likely is spam)

## tests
tested on a private test discord server with a private bot (copied the one from this repo and kicked all the stuff that needs access to lp api and then added the changes)

![Screenshot 2023-01-24 15 26 33](https://user-images.githubusercontent.com/75081997/214320839-b63683c3-6461-4fad-af5e-549917ec64d7.png)
![Screenshot 2023-01-24 15 26 47](https://user-images.githubusercontent.com/75081997/214320847-ab412612-8635-4e5e-820c-8819cd9e4db9.png)
