### PR TITLE
Adding support to self assign VAL Predictions role

### DIFF
--- a/ftsbot/data.py
+++ b/ftsbot/data.py
@@ -194,6 +194,7 @@ botroles = [
 	'Random Stats of the Day',
 	'R6 Predictions',
 	'Templates',
+	'VAL Predictions',
 ]
 
 # Words regularly used in invite spams


### PR DESCRIPTION
Added VAL Predictions as one of the assignable roles as per the request of the valorant contributors.