### PR TITLE
Add API Announcements role

### DIFF
--- a/ftsbot/data.py
+++ b/ftsbot/data.py
@@ -191,6 +191,7 @@ botroles = [
 	'Vietnamese',
 
 	'Announcements',
+	'API Announcements',
 	'App Announcements',
 	'CS Predictions',
 	'Game Night',


### PR DESCRIPTION
Allows for mass pings to people interested in any developments regarding the LPDB API. 
I will write some instructions in the #api-help channel describing how to add the role. 
The use case would be announcements in the #updates-api channel https://discord.com/channels/93055209017729024/1209073487566602261/1248667514259505172