### PR TITLE
Add Sideswipe to bot roles

### DIFF
--- a/ftsbot/data.py
+++ b/ftsbot/data.py
@@ -141,6 +141,7 @@ botroles = [
 	'Rainbow Six',
 	'Rocket League',
 	'Runeterra',
+	'Sideswipe',
 	'Sim Racing',
 	'Smash',
 	'SMITE',


### PR DESCRIPTION
The role exists but can’t be added via FTS bot