### PR TITLE
Add ping feature for Reviewers

### DIFF
--- a/ftsbot/cogs/pingcommands.py
+++ b/ftsbot/cogs/pingcommands.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+# License MIT
+# Copyright 2016-2025 Alex Winkler
+# Version 4.1.0
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+from ftsbot import config, data
+from ftsbot.functions import autocomplete
+
+
+class pingcommands(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    def is_reviewer(self, interaction: discord.Interaction) -> bool:
+        """Check if user has reviewer role"""
+        user_roles = [role.name for role in interaction.user.roles]
+        return data.reviewer_role in user_roles
+
+    @app_commands.command(description='Ping a specific role with custom text (Reviewers only)')
+    @app_commands.describe(
+        role='Which role do you want to ping?',
+        message='What message do you want to send?'
+    )
+    @app_commands.guild_only()
+    @app_commands.autocomplete(role=autocomplete.pingable_roles)
+    async def ping(
+        self,
+        interaction: discord.Interaction,
+        role: str,
+        message: str
+    ):
+        """
+        Command to ping specific roles with custom text.
+        Only accessible to reviewers.
+        """
+        # Check permissions
+        if not self.is_reviewer(interaction):
+            await interaction.response.send_message(
+                embed=discord.Embed(
+                    colour=discord.Colour(0xFF0000),
+                    description='**Error**: Only reviewers can use this command'
+                ),
+                ephemeral=True
+            )
+            return
+
+        # Validate role exists in pingable_roles
+        if role not in data.pingable_roles:
+            available_roles = ', '.join(data.pingable_roles.keys())
+            await interaction.response.send_message(
+                embed=discord.Embed(
+                    colour=discord.Colour(0xFF0000),
+                    description=f'**Error**: Invalid role. Available roles: {available_roles}'
+                ),
+                ephemeral=True
+            )
+            return
+
+        # Get the actual Discord role
+        role_name = data.pingable_roles[role]
+        discord_role = discord.utils.get(interaction.guild.roles, name=role_name)
+
+        if discord_role is None:
+            await interaction.response.send_message(
+                embed=discord.Embed(
+                    colour=discord.Colour(0xFF0000),
+                    description=f'**Error**: Role "{role_name}" not found in server'
+                ),
+                ephemeral=True
+            )
+            return
+
+        # Build the message with role mention
+        ping_message = f"{discord_role.mention}\n{message}"
+
+        try:
+            # Send the ping message to the channel
+            await interaction.channel.send(ping_message)
+            
+            await interaction.response.send_message(
+                embed=discord.Embed(
+                    colour=discord.Colour(0x00FF00),
+                    description=f'**Success**: Pinged {discord_role.name} with your message'
+                ),
+                ephemeral=True
+            )
+        except discord.Forbidden:
+            await interaction.response.send_message(
+                embed=discord.Embed(
+                    colour=discord.Colour(0xFF0000),
+                    description='**Error**: Bot does not have permission to mention this role'
+                ),
+                ephemeral=True
+            )
+        except Exception as e:
+            await interaction.response.send_message(
+                embed=discord.Embed(
+                    colour=discord.Colour(0xFF0000),
+                    description=f'**Error**: {str(e)}'
+                ),
+                ephemeral=True
+            )
+
+
+async def setup(bot):
+    await bot.add_cog(pingcommands(bot))

--- a/ftsbot/cogs/pingcommands.py
+++ b/ftsbot/cogs/pingcommands.py
@@ -22,12 +22,12 @@ class pingcommands(commands.Cog):
 	)
 	@app_commands.guild_only()
 	@app_commands.autocomplete(role=autocomplete.pingable_roles)
-	@app_commands.checks.has_any_role('Reviewer', 'Administrator') # You can add more roles here if needed
+	@app_commands.checks.has_any_role('Reviewer', 'Administrator')
 	async def ping(self, interaction: discord.Interaction, role: str, message: str):
 
-		# Validate role exists in pingable_roles
+		# Validate role exists in pingable_roles list
 		if role not in data.pingable_roles:
-			available_roles = ', '.join(data.pingable_roles.values())
+			available_roles = ', '.join(data.pingable_roles)
 			await interaction.response.send_message(
 				embed=discord.Embed(
 					colour=discord.Colour(0xFF0000),
@@ -38,14 +38,13 @@ class pingcommands(commands.Cog):
 			return
 
 		# Get the actual Discord role
-		role_name = data.pingable_roles[role]
-		discord_role = discord.utils.get(interaction.guild.roles, name=role_name)
+		discord_role = discord.utils.get(interaction.guild.roles, name=role)
 
 		if discord_role is None:
 			await interaction.response.send_message(
 				embed=discord.Embed(
 					colour=discord.Colour(0xFF0000),
-					description=f'**Error**: Role "{role_name}" not found in server'
+					description=f'**Error**: Role "{role}" not found in server'
 				),
 				ephemeral=True
 			)

--- a/ftsbot/cogs/pingcommands.py
+++ b/ftsbot/cogs/pingcommands.py
@@ -15,82 +15,82 @@ class pingcommands(commands.Cog):
 	def __init__(self, bot):
 		self.bot = bot
 
-@app_commands.command(description='Ping a specific role with custom text (Reviewers only)')
-@app_commands.describe(
-    role='Which role do you want to ping?',
-    message='What message do you want to send?'
-)
-@app_commands.guild_only()
-@app_commands.autocomplete(role=autocomplete.pingable_roles)
-@app_commands.checks.has_any_role('Reviewer', 'Administrator')
-async def ping(self, interaction: discord.Interaction, role: str, message: str):
+	@app_commands.command(description='Ping a specific role with custom text (Reviewers only)')
+	@app_commands.describe(
+		role='Which role do you want to ping?',
+		message='What message do you want to send?'
+	)
+	@app_commands.guild_only()
+	@app_commands.autocomplete(role=autocomplete.pingable_roles)
+	@app_commands.checks.has_any_role('Reviewer', 'Administrator')
+	async def ping(self, interaction: discord.Interaction, role: str, message: str):
 
-    # Defer the response so the interaction doesn't timeout if Discord is slow
-    await interaction.response.defer(ephemeral=True)
+		# Defer the response so the interaction doesn't timeout if Discord is slow
+		await interaction.response.defer(ephemeral=True)
 
-    # Validate role exists in pingable_roles list
-    if role not in data.pingable_roles:
-        available_roles = ', '.join(data.pingable_roles)
-        await interaction.followup.send(
-            embed=discord.Embed(
-                colour=discord.Colour(0xFF0000),
-                description=f'**Error**: Invalid role. Available roles: {available_roles}'
-            )
-        )
-        return
+		# Validate role exists in pingable_roles list
+		if role not in data.pingable_roles:
+			available_roles = ', '.join(data.pingable_roles)
+			await interaction.followup.send(
+				embed=discord.Embed(
+					colour=discord.Colour(0xFF0000),
+					description=f'**Error**: Invalid role. Available roles: {available_roles}'
+				)
+			)
+			return
 
-    # Get the actual Discord role
-    discord_role = discord.utils.get(interaction.guild.roles, name=role)
+		# Get the actual Discord role
+		discord_role = discord.utils.get(interaction.guild.roles, name=role)
 
-    if discord_role is None:
-        await interaction.followup.send(
-            embed=discord.Embed(
-                colour=discord.Colour(0xFF0000),
-                description=f'**Error**: Role "{role}" not found in server'
-            )
-        )
-        return
+		if discord_role is None:
+			await interaction.followup.send(
+				embed=discord.Embed(
+					colour=discord.Colour(0xFF0000),
+					description=f'**Error**: Role "{role}" not found in server'
+				)
+			)
+			return
 
-    # Build the message with role mention AND attribution
-    ping_message = f"{discord_role.mention}\n**Message from {interaction.user.mention}:**\n{message}"
-    
-    # Prevent crashing from Discord's 2k character limit
-    if len(ping_message) > 2000:
-        await interaction.followup.send(
-            embed=discord.Embed(
-                colour=discord.Colour(0xFF0000),
-                description='**Error**: Your message is too long! It must be under 2000 characters.'
-            )
-        )
-        return
-    
-    # EXPLICITLY allow the bot to bypass the native ping restriction
-    allowed_mentions = discord.AllowedMentions(roles=[discord_role])
+		# Build the message with role mention AND attribution
+		ping_message = f"{discord_role.mention}\n**Message from {interaction.user.mention}:**\n{message}"
+		
+		# Prevent crashing from Discord's 2k character limit
+		if len(ping_message) > 2000:
+			await interaction.followup.send(
+				embed=discord.Embed(
+					colour=discord.Colour(0xFF0000),
+					description='**Error**: Your message is too long! It must be under 2000 characters.'
+				)
+			)
+			return
+		
+		# EXPLICITLY allow the bot to bypass the native ping restriction
+		allowed_mentions = discord.AllowedMentions(roles=[discord_role])
 
-    try:
-        # Send the ping message to the channel
-        await interaction.channel.send(content=ping_message, allowed_mentions=allowed_mentions)
-        
-        await interaction.followup.send(
-            embed=discord.Embed(
-                colour=discord.Colour(0x00FF00),
-                description=f'**Success**: Pinged {discord_role.name} with your message'
-            )
-        )
-    except discord.Forbidden:
-        await interaction.followup.send(
-            embed=discord.Embed(
-                colour=discord.Colour(0xFF0000),
-                description='**Error**: Bot does not have permission to send messages or mention roles in this channel'
-            )
-        )
-    except Exception as e:
-        await interaction.followup.send(
-            embed=discord.Embed(
-                colour=discord.Colour(0xFF0000),
-                description=f'**Error**: {str(e)}'
-            )
-        )
+		try:
+			# Send the ping message to the channel
+			await interaction.channel.send(content=ping_message, allowed_mentions=allowed_mentions)
+			
+			await interaction.followup.send(
+				embed=discord.Embed(
+					colour=discord.Colour(0x00FF00),
+					description=f'**Success**: Pinged {discord_role.name} with your message'
+				)
+			)
+		except discord.Forbidden:
+			await interaction.followup.send(
+				embed=discord.Embed(
+					colour=discord.Colour(0xFF0000),
+					description='**Error**: Bot does not have permission to send messages or mention roles in this channel'
+				)
+			)
+		except Exception as e:
+			await interaction.followup.send(
+				embed=discord.Embed(
+					colour=discord.Colour(0xFF0000),
+					description=f'**Error**: {str(e)}'
+				)
+			)
 
 	# This catches the error if a normal user tries to run the command
 	@ping.error
@@ -108,3 +108,4 @@ async def ping(self, interaction: discord.Interaction, role: str, message: str):
 
 async def setup(bot):
 	await bot.add_cog(pingcommands(bot))
+	

--- a/ftsbot/cogs/pingcommands.py
+++ b/ftsbot/cogs/pingcommands.py
@@ -7,104 +7,97 @@
 import discord
 from discord import app_commands
 from discord.ext import commands
-from ftsbot import config, data
+from ftsbot import data
 from ftsbot.functions import autocomplete
 
 
 class pingcommands(commands.Cog):
-    def __init__(self, bot):
-        self.bot = bot
+	def __init__(self, bot):
+		self.bot = bot
 
-    def is_reviewer(self, interaction: discord.Interaction) -> bool:
-        """Check if user has reviewer role"""
-        user_roles = [role.name for role in interaction.user.roles]
-        return data.reviewer_role in user_roles
+	@app_commands.command(description='Ping a specific role with custom text (Reviewers only)')
+	@app_commands.describe(
+		role='Which role do you want to ping?',
+		message='What message do you want to send?'
+	)
+	@app_commands.guild_only()
+	@app_commands.autocomplete(role=autocomplete.pingable_roles)
+	@app_commands.checks.has_any_role('Reviewer', 'Administrator') # You can add more roles here if needed
+	async def ping(self, interaction: discord.Interaction, role: str, message: str):
 
-    @app_commands.command(description='Ping a specific role with custom text (Reviewers only)')
-    @app_commands.describe(
-        role='Which role do you want to ping?',
-        message='What message do you want to send?'
-    )
-    @app_commands.guild_only()
-    @app_commands.autocomplete(role=autocomplete.pingable_roles)
-    async def ping(
-        self,
-        interaction: discord.Interaction,
-        role: str,
-        message: str
-    ):
-        """
-        Command to ping specific roles with custom text.
-        Only accessible to reviewers.
-        """
-        # Check permissions
-        if not self.is_reviewer(interaction):
-            await interaction.response.send_message(
-                embed=discord.Embed(
-                    colour=discord.Colour(0xFF0000),
-                    description='**Error**: Only reviewers can use this command'
-                ),
-                ephemeral=True
-            )
-            return
+		# Validate role exists in pingable_roles
+		if role not in data.pingable_roles:
+			available_roles = ', '.join(data.pingable_roles.values())
+			await interaction.response.send_message(
+				embed=discord.Embed(
+					colour=discord.Colour(0xFF0000),
+					description=f'**Error**: Invalid role. Available roles: {available_roles}'
+				),
+				ephemeral=True
+			)
+			return
 
-        # Validate role exists in pingable_roles
-        if role not in data.pingable_roles:
-            available_roles = ', '.join(data.pingable_roles.keys())
-            await interaction.response.send_message(
-                embed=discord.Embed(
-                    colour=discord.Colour(0xFF0000),
-                    description=f'**Error**: Invalid role. Available roles: {available_roles}'
-                ),
-                ephemeral=True
-            )
-            return
+		# Get the actual Discord role
+		role_name = data.pingable_roles[role]
+		discord_role = discord.utils.get(interaction.guild.roles, name=role_name)
 
-        # Get the actual Discord role
-        role_name = data.pingable_roles[role]
-        discord_role = discord.utils.get(interaction.guild.roles, name=role_name)
+		if discord_role is None:
+			await interaction.response.send_message(
+				embed=discord.Embed(
+					colour=discord.Colour(0xFF0000),
+					description=f'**Error**: Role "{role_name}" not found in server'
+				),
+				ephemeral=True
+			)
+			return
 
-        if discord_role is None:
-            await interaction.response.send_message(
-                embed=discord.Embed(
-                    colour=discord.Colour(0xFF0000),
-                    description=f'**Error**: Role "{role_name}" not found in server'
-                ),
-                ephemeral=True
-            )
-            return
+		# Build the message with role mention
+		ping_message = f"{discord_role.mention}\n{message}"
+		
+		# EXPLICITLY allow the bot to bypass the native ping restriction
+		allowed_mentions = discord.AllowedMentions(roles=[discord_role])
 
-        # Build the message with role mention
-        ping_message = f"{discord_role.mention}\n{message}"
+		try:
+			# Send the ping message to the channel
+			await interaction.channel.send(content=ping_message, allowed_mentions=allowed_mentions)
+			
+			await interaction.response.send_message(
+				embed=discord.Embed(
+					colour=discord.Colour(0x00FF00),
+					description=f'**Success**: Pinged {discord_role.name} with your message'
+				),
+				ephemeral=True
+			)
+		except discord.Forbidden:
+			await interaction.response.send_message(
+				embed=discord.Embed(
+					colour=discord.Colour(0xFF0000),
+					description='**Error**: Bot does not have permission to send messages or mention roles in this channel'
+				),
+				ephemeral=True
+			)
+		except Exception as e:
+			await interaction.response.send_message(
+				embed=discord.Embed(
+					colour=discord.Colour(0xFF0000),
+					description=f'**Error**: {str(e)}'
+				),
+				ephemeral=True
+			)
 
-        try:
-            # Send the ping message to the channel
-            await interaction.channel.send(ping_message)
-            
-            await interaction.response.send_message(
-                embed=discord.Embed(
-                    colour=discord.Colour(0x00FF00),
-                    description=f'**Success**: Pinged {discord_role.name} with your message'
-                ),
-                ephemeral=True
-            )
-        except discord.Forbidden:
-            await interaction.response.send_message(
-                embed=discord.Embed(
-                    colour=discord.Colour(0xFF0000),
-                    description='**Error**: Bot does not have permission to mention this role'
-                ),
-                ephemeral=True
-            )
-        except Exception as e:
-            await interaction.response.send_message(
-                embed=discord.Embed(
-                    colour=discord.Colour(0xFF0000),
-                    description=f'**Error**: {str(e)}'
-                ),
-                ephemeral=True
-            )
-
+	# This catches the error if a normal user tries to run the command
+	@ping.error
+	async def on_ping_error(self, interaction: discord.Interaction, error: app_commands.AppCommandError):
+		if isinstance(error, app_commands.MissingAnyRole) or isinstance(error, app_commands.MissingRole):
+			await interaction.response.send_message(
+				embed=discord.Embed(
+					colour=discord.Colour(0xFF0000),
+					description='**Error**: Only Reviewers can use this command'
+				),
+				ephemeral=True
+			)
+		else:
+			await interaction.response.send_message(str(error), ephemeral=True)
 
 async def setup(bot):
-    await bot.add_cog(pingcommands(bot))
+	await bot.add_cog(pingcommands(bot))

--- a/ftsbot/cogs/pingcommands.py
+++ b/ftsbot/cogs/pingcommands.py
@@ -15,74 +15,82 @@ class pingcommands(commands.Cog):
 	def __init__(self, bot):
 		self.bot = bot
 
-	@app_commands.command(description='Ping a specific role with custom text (Reviewers only)')
-	@app_commands.describe(
-		role='Which role do you want to ping?',
-		message='What message do you want to send?'
-	)
-	@app_commands.guild_only()
-	@app_commands.autocomplete(role=autocomplete.pingable_roles)
-	@app_commands.checks.has_any_role('Reviewer', 'Administrator')
-	async def ping(self, interaction: discord.Interaction, role: str, message: str):
+@app_commands.command(description='Ping a specific role with custom text (Reviewers only)')
+@app_commands.describe(
+    role='Which role do you want to ping?',
+    message='What message do you want to send?'
+)
+@app_commands.guild_only()
+@app_commands.autocomplete(role=autocomplete.pingable_roles)
+@app_commands.checks.has_any_role('Reviewer', 'Administrator')
+async def ping(self, interaction: discord.Interaction, role: str, message: str):
 
-		# Validate role exists in pingable_roles list
-		if role not in data.pingable_roles:
-			available_roles = ', '.join(data.pingable_roles)
-			await interaction.response.send_message(
-				embed=discord.Embed(
-					colour=discord.Colour(0xFF0000),
-					description=f'**Error**: Invalid role. Available roles: {available_roles}'
-				),
-				ephemeral=True
-			)
-			return
+    # Defer the response so the interaction doesn't timeout if Discord is slow
+    await interaction.response.defer(ephemeral=True)
 
-		# Get the actual Discord role
-		discord_role = discord.utils.get(interaction.guild.roles, name=role)
+    # Validate role exists in pingable_roles list
+    if role not in data.pingable_roles:
+        available_roles = ', '.join(data.pingable_roles)
+        await interaction.followup.send(
+            embed=discord.Embed(
+                colour=discord.Colour(0xFF0000),
+                description=f'**Error**: Invalid role. Available roles: {available_roles}'
+            )
+        )
+        return
 
-		if discord_role is None:
-			await interaction.response.send_message(
-				embed=discord.Embed(
-					colour=discord.Colour(0xFF0000),
-					description=f'**Error**: Role "{role}" not found in server'
-				),
-				ephemeral=True
-			)
-			return
+    # Get the actual Discord role
+    discord_role = discord.utils.get(interaction.guild.roles, name=role)
 
-		# Build the message with role mention
-		ping_message = f"{discord_role.mention}\n{message}"
-		
-		# EXPLICITLY allow the bot to bypass the native ping restriction
-		allowed_mentions = discord.AllowedMentions(roles=[discord_role])
+    if discord_role is None:
+        await interaction.followup.send(
+            embed=discord.Embed(
+                colour=discord.Colour(0xFF0000),
+                description=f'**Error**: Role "{role}" not found in server'
+            )
+        )
+        return
 
-		try:
-			# Send the ping message to the channel
-			await interaction.channel.send(content=ping_message, allowed_mentions=allowed_mentions)
-			
-			await interaction.response.send_message(
-				embed=discord.Embed(
-					colour=discord.Colour(0x00FF00),
-					description=f'**Success**: Pinged {discord_role.name} with your message'
-				),
-				ephemeral=True
-			)
-		except discord.Forbidden:
-			await interaction.response.send_message(
-				embed=discord.Embed(
-					colour=discord.Colour(0xFF0000),
-					description='**Error**: Bot does not have permission to send messages or mention roles in this channel'
-				),
-				ephemeral=True
-			)
-		except Exception as e:
-			await interaction.response.send_message(
-				embed=discord.Embed(
-					colour=discord.Colour(0xFF0000),
-					description=f'**Error**: {str(e)}'
-				),
-				ephemeral=True
-			)
+    # Build the message with role mention AND attribution
+    ping_message = f"{discord_role.mention}\n**Message from {interaction.user.mention}:**\n{message}"
+    
+    # Prevent crashing from Discord's 2k character limit
+    if len(ping_message) > 2000:
+        await interaction.followup.send(
+            embed=discord.Embed(
+                colour=discord.Colour(0xFF0000),
+                description='**Error**: Your message is too long! It must be under 2000 characters.'
+            )
+        )
+        return
+    
+    # EXPLICITLY allow the bot to bypass the native ping restriction
+    allowed_mentions = discord.AllowedMentions(roles=[discord_role])
+
+    try:
+        # Send the ping message to the channel
+        await interaction.channel.send(content=ping_message, allowed_mentions=allowed_mentions)
+        
+        await interaction.followup.send(
+            embed=discord.Embed(
+                colour=discord.Colour(0x00FF00),
+                description=f'**Success**: Pinged {discord_role.name} with your message'
+            )
+        )
+    except discord.Forbidden:
+        await interaction.followup.send(
+            embed=discord.Embed(
+                colour=discord.Colour(0xFF0000),
+                description='**Error**: Bot does not have permission to send messages or mention roles in this channel'
+            )
+        )
+    except Exception as e:
+        await interaction.followup.send(
+            embed=discord.Embed(
+                colour=discord.Colour(0xFF0000),
+                description=f'**Error**: {str(e)}'
+            )
+        )
 
 	# This catches the error if a normal user tries to run the command
 	@ping.error

--- a/ftsbot/data.py
+++ b/ftsbot/data.py
@@ -107,6 +107,17 @@ wikiroles = {
 	'reviewer': 'Reviewer',
 }
 
+# Roles which could use pingable roles command
+reviewer_role = 'Reviewer'
+
+# Map of pingable roles
+pingable_roles = {
+    'cs': 'CS Predictions',
+    'ml': 'ML Predictions',
+    'val': 'VAL Predictions',
+    'r6': 'R6 Predictions',
+}
+
 # Roles the bot can add and remove
 botroles = [
 	'Age of Empires',

--- a/ftsbot/data.py
+++ b/ftsbot/data.py
@@ -112,10 +112,10 @@ reviewer_role = 'Reviewer'
 
 # Map of pingable roles
 pingable_roles = {
-    'cs': 'CS Predictions',
-    'ml': 'ML Predictions',
-    'val': 'VAL Predictions',
-    'r6': 'R6 Predictions',
+	'cs': 'CS Predictions',
+	'ml': 'ML Predictions',
+	'val': 'VAL Predictions',
+	'r6': 'R6 Predictions',
 }
 
 # Roles the bot can add and remove

--- a/ftsbot/data.py
+++ b/ftsbot/data.py
@@ -107,16 +107,13 @@ wikiroles = {
 	'reviewer': 'Reviewer',
 }
 
-# Roles which could use pingable roles command
-reviewer_role = 'Reviewer'
-
 # Map of pingable roles
-pingable_roles = {
-	'cs': 'CS Predictions',
-	'ml': 'ML Predictions',
-	'val': 'VAL Predictions',
-	'r6': 'R6 Predictions',
-}
+pingable_roles = [
+	'CS Predictions',
+	'ML Predictions',
+	'R6 Predictions',
+	'VAL Predictions',
+]
 
 # Roles the bot can add and remove
 botroles = [

--- a/ftsbot/functions/autocomplete.py
+++ b/ftsbot/functions/autocomplete.py
@@ -29,3 +29,12 @@ async def roles(interaction: discord.Interaction, current: str) -> list[app_comm
 	roles.sort(key=sortroles)
 
 	return [app_commands.Choice(name=role, value=role) for role in roles][:25]
+
+async def pingable_roles(interaction: discord.Interaction, current: str) -> list[app_commands.Choice[str]]:
+	choices =[]
+	for key, name in data.pingable_roles.items():
+		if current.lower() in name.lower() or current.lower() in key.lower():
+			choices.append(app_commands.Choice(name=name, value=key))
+	
+	return choices[:25]
+	

--- a/ftsbot/functions/autocomplete.py
+++ b/ftsbot/functions/autocomplete.py
@@ -31,10 +31,12 @@ async def roles(interaction: discord.Interaction, current: str) -> list[app_comm
 	return [app_commands.Choice(name=role, value=role) for role in roles][:25]
 
 async def pingable_roles(interaction: discord.Interaction, current: str) -> list[app_commands.Choice[str]]:
-	choices =[]
-	for key, name in data.pingable_roles.items():
-		if current.lower() in name.lower() or current.lower() in key.lower():
-			choices.append(app_commands.Choice(name=name, value=key))
-	
-	return choices[:25]
+	roles = [role for role in data.pingable_roles if current.lower() in role.lower()]
+
+	def sortroles(element):
+		return element.lower().index(current.lower())
+
+	roles.sort(key=sortroles)
+
+	return [app_commands.Choice(name=role, value=role) for role in roles][:25]
 	

--- a/ftsbot/liquipediabot.py
+++ b/ftsbot/liquipediabot.py
@@ -9,6 +9,7 @@ from discord.ext import commands
 from ftsbot import config
 from ftsbot.cogs.antispam import antispam
 from ftsbot.cogs.channelmoderation import channelmoderation
+from ftsbot.cogs.pingcommands import pingcommands
 from ftsbot.cogs.presence import presence
 from ftsbot.cogs.rolecommands import rolecommands
 from ftsbot.cogs.textcommands import textcommands
@@ -32,6 +33,7 @@ class liquipediabot(commands.Bot):
 	async def setup_hook(self):
 		await self.add_cog(antispam(self))
 		await self.add_cog(channelmoderation(self))
+		await self.add_cog(pingcommands(self))
 		await self.add_cog(presence(self))
 		await self.add_cog(rolecommands(self))
 		await self.add_cog(textcommands(self))


### PR DESCRIPTION
## Summary

Discussed on the Admin discord. Opened discussion also in the reviewer channel.
Admin discord:
https://discord.com/channels/321003439431745537/498858609862508554/1489842007810510918

Reviewer channel: (public)
https://discord.com/channels/93055209017729024/1499105603463811253/1501249427313266738

**Definitely need checking. Made with AI help.** 
I tried my best :D
Allowed it only to reviewers as admins etc.. can just ping normally, but I guess I could also allow admins to use this ping feature. Just didn't saw point of that.

## How did you test this change?
Tested on my private server
<img width="1310" height="703" alt="image" src="https://github.com/user-attachments/assets/1bad812a-9ee3-4670-819e-7a5d73df42e6" />
<img width="481" height="309" alt="image" src="https://github.com/user-attachments/assets/40f21063-6fa7-4f23-8edd-9e6aa018a5ca" />
